### PR TITLE
set and export

### DIFF
--- a/InternalCommands.cpp
+++ b/InternalCommands.cpp
@@ -94,31 +94,19 @@ void InternalCommands::pauseCmd(){
 /**
  * Searches through the environMap to find the given key value
  */
-string InternalCommands::showEnvironValue(const string& arg)
+int InternalCommands::showEnvironValue(const string& arg)
 {
 	//Case of where argument is in the form $ and string of chars ex: $TEST:
 	// will search value by the key TEST and return value.
-	string key = arg.substr(1, arg.size() - 1);
-	map<string, string>::iterator isThere;
+	string key = arg.substr(1);
 
-	//If the key exists in environment print the value
-	if ((isThere = environMap.find(key)) != environMap.end()) {
-        cout << "environ:" <<endl;
-		cout << isThere->second << " ";
+	int status = (environMap.find(key) != environMap.end());
 
-    //If the key is set locally print the value
-        
-    //This could be its own method or command if we want to seperate it. Or, use a flag for showing environ vs local variables. ex: show -e : show environ, show -l : show local, show : show all
+	//If the key exists print the value
+	if (status) {
+		cout << environMap.at(key) << " ";
 	}
-    else if((isThere = localMap.find(key)) != localMap.end()){
-        cout << "local:" <<endl;
-        cout << isThere->second<< " ";
-    }
-    //else we simply print the arg as it was.
-    else {
-		cout << arg << " ";
-	}
-	return key;
+	return status;
 }
 
 /**
@@ -182,7 +170,7 @@ void InternalCommands::echoCommand(char * eCmd)
    string eCommand = eCmd;
    int firstElement = eCommand.find("echo");
    //Remove the subsring "echoc"
-   eCommand.erase(firstElement, 4);
+   eCommand.erase(firstElement, 5);
    cout <<eCommand;
 
 }

--- a/InternalCommands.cpp
+++ b/InternalCommands.cpp
@@ -200,7 +200,7 @@ void InternalCommands::setCmd(char * cmd, vector<string> args){
     string eCommand = cmd;
     string delim = " ";
     
-    //get rid of the export cmd
+    //get rid of the set cmd
     eCommand.erase(eCommand.find("set"), 4);
     
     //get W1 and W2
@@ -212,15 +212,14 @@ void InternalCommands::setCmd(char * cmd, vector<string> args){
     
     //make W1 all caps
     transform(W1.begin(), W1.end(), W1.begin(), ::toupper);
-    //add W2 to index W1 of environMap
-        cout << W1 << W2 <<endl;
+    //add W2 to index W1 of localMap
     localMap[W1] = W2;
     }
 }
 
 void InternalCommands::unsetCmd(char * cmd){
     string eCommand = cmd;
-    //get rid of the unexport cmd
+    //get rid of the unset cmd
     eCommand.erase(eCommand.find("unset"), 6);
     //Get W1
     string W1 = eCommand;
@@ -228,7 +227,7 @@ void InternalCommands::unsetCmd(char * cmd){
     
     //make W1 all caps
     transform(W1.begin(), W1.end(), W1.begin(), ::toupper);
-    //remove W1 from map if it exists
+    //remove W1 from localMap if it exists
     localMap.erase(W1);
 }
 

--- a/InternalCommands.cpp
+++ b/InternalCommands.cpp
@@ -107,6 +107,8 @@ string InternalCommands::showEnvironValue(const string& arg)
 		cout << isThere->second << " ";
 
     //If the key is set locally print the value
+        
+    //This could be its own method or command if we want to seperate it. Or, use a flag for showing environ vs local variables. ex: show -e : show environ, show -l : show local, show : show all
 	}
     else if((isThere = localMap.find(key)) != localMap.end()){
         cout << "local:" <<endl;

--- a/InternalCommands.cpp
+++ b/InternalCommands.cpp
@@ -106,12 +106,13 @@ string InternalCommands::showEnvironValue(const string& arg)
         cout << "environ:" <<endl;
 		cout << isThere->second << " ";
 
-		//else we simply print the arg as it was.
+    //If the key is set locally print the value
 	}
     else if((isThere = localMap.find(key)) != localMap.end()){
         cout << "local:" <<endl;
         cout << isThere->second<< " ";
     }
+    //else we simply print the arg as it was.
     else {
 		cout << arg << " ";
 	}

--- a/InternalCommands.h
+++ b/InternalCommands.h
@@ -17,7 +17,8 @@ class InternalCommands
    InternalCommands();   
    //Destructor
    ~InternalCommands();
-
+   //setEnvVars: set the enviromental variables (exported vars) from external file storage
+   void setEnvVars();
    //clr: Clear the screen and display a new command line prompt at the top.
    void clearScreen();
    //pause: Pause the shell until the Enter button is pressed
@@ -29,6 +30,11 @@ class InternalCommands
   //   new line.
   void  echoCommand(char *  eCmd);
 
+  // set and unset
+  // set and unset the value of local variables, stored in localMap
+  void setCmd(char * cmd, vector<string>args);
+  void unsetCmd(char * cmd);
+    
   //HISTORY related methods:
   // history() prints the history
   // FIFO structure:
@@ -43,7 +49,7 @@ class InternalCommands
 
   //export: export <W1> <W2>:
   //	sets environment variable <W1>.toupper() to value <W2>
-  void exportCmd(char * cmd);
+  void exportCmd(char * cmd, vector<string> args);
   
   //unexport: unexport <W1>:
   //	removes <W1> from set environment variables
@@ -65,6 +71,7 @@ class InternalCommands
   private:
   vector <string> historyList;
   map <string, string> environMap;
+  map <string, string> localMap;
   unsigned int longestIndex;
 
   //private functions:

--- a/xsh.cpp
+++ b/xsh.cpp
@@ -32,6 +32,7 @@ void xshLoop(void)
   char *line = NULL;
   int status;
   
+  ic.setEnvVars();
 
   do {
      cout <<"xsh >> ";
@@ -98,6 +99,14 @@ int HandleInput(char* line, BasicTasks* bt, InternalCommands* ic)
          ic->echoCommand(preservedLine);
          ic->addCmdToHistory(preservedLine);
      }
+     else if(args.at(0) == "set"){
+         ic ->setCmd(preservedLine, args);
+         ic->addCmdToHistory(preservedLine);
+     }
+     else if(args.at(0)== "unset"){
+         ic->unsetCmd(preservedLine);
+         ic->addCmdToHistory(preservedLine);
+     }
 	 else if(args.at(0)=="show")
      {
          ic->showCommand(args);
@@ -110,7 +119,7 @@ int HandleInput(char* line, BasicTasks* bt, InternalCommands* ic)
      } 
 	 else if(args.at(0) =="export")
 	 {
-		 ic->exportCmd(preservedLine);
+		 ic->exportCmd(preservedLine, args);
          ic->addCmdToHistory(preservedLine);
 	 }
 	 else if(args.at(0) =="unexport")


### PR DESCRIPTION
Added set and unset, changed export unexport, added helper methods

To make export different from set, I created an output file where all environmental variables (export) are stored. This is different from set because these variables are available to every shell instance (they are scanned into the shell when the program is started). Locally these environmental variables are stored in environMap 

The set method sets local variables that are only available to that instance of the shell. These are stored in localMap. 

The show method now loops through both maps, printing all environmental variables(exported) and then local variables (set). 